### PR TITLE
Fixes spelling of 'contactRole' (concactRole)

### DIFF
--- a/src/controller/ReportsController.test.ts
+++ b/src/controller/ReportsController.test.ts
@@ -70,7 +70,7 @@ describe("#create", () => {
     const waitTime = "5";
     const contactFirstName = "Jim";
     const contactLastName = "Jim";
-    const concactRole = "Poll Worker";
+    const contactRole = "Poll Worker";
     const canDistribute = true;
 
     const request = http_mocks.createRequest({
@@ -82,7 +82,7 @@ describe("#create", () => {
         waitTime,
         contactFirstName,
         contactLastName,
-        concactRole,
+        contactRole,
         canDistribute,
       },
     });
@@ -111,7 +111,7 @@ describe("#create", () => {
     expect(report.waitTime).toEqual(waitTime);
     expect(report.contactFirstName).toEqual(contactFirstName);
     expect(report.contactLastName).toEqual(contactLastName);
-    expect(report.concactRole).toEqual(concactRole);
+    expect(report.contactRole).toEqual(contactRole);
 
     const [zapUrl, { body: zapBody }] = fetch.mock.calls[0];
     expect(zapUrl).toEqual(process.env.ZAP_NEW_LOCATION);

--- a/src/entity/Report.ts
+++ b/src/entity/Report.ts
@@ -38,7 +38,7 @@ export class Report extends BaseEntity {
   contactLastName: string;
 
   @Column({ name: "contact_role", nullable: true })
-  concactRole: string;
+  contactRole: string;
 
   @Column({ name: "wait_time", nullable: true })
   waitTime: string;
@@ -107,7 +107,7 @@ export class Report extends BaseEntity {
       contactInfo,
       contactFirstName,
       contactLastName,
-      concactRole,
+      contactRole,
       canDistribute,
     } = this;
 
@@ -116,7 +116,7 @@ export class Report extends BaseEntity {
       contactInfo,
       contactFirstName,
       contactLastName,
-      concactRole,
+      contactRole,
       canDistribute: canDistribute > 0,
     };
   }
@@ -149,14 +149,14 @@ export class Report extends BaseEntity {
       waitTime,
       contactFirstName,
       contactLastName,
-      concactRole,
+      contactRole,
       canDistribute,
     }: {
       waitTime?: string;
       canDistribute?: boolean;
       contactFirstName?: string;
       contactLastName?: string;
-      concactRole?: string;
+      contactRole?: string;
     } = {}
   ): Promise<
     [
@@ -187,7 +187,7 @@ export class Report extends BaseEntity {
     report.waitTime = waitTime;
     report.contactFirstName = contactFirstName;
     report.contactLastName = contactLastName;
-    report.concactRole = concactRole;
+    report.contactRole = contactRole;
 
     const reportExists = await this.findOne({
       where: { reportURL, location: report.location },

--- a/src/lib/validator/validateReport.ts
+++ b/src/lib/validator/validateReport.ts
@@ -17,7 +17,7 @@ export const validateReport = async ({
   canDistribute,
   contactFirstName,
   contactLastName,
-  concactRole,
+  contactRole,
 }: {
   address?: string;
   contact?: string;
@@ -25,7 +25,7 @@ export const validateReport = async ({
   waitTime?: string;
   contactFirstName?: string;
   contactLastName?: string;
-  concactRole?: string;
+  contactRole?: string;
   canDistribute?: boolean;
 }): Promise<{
   normalizedAddress: NormalAddress;
@@ -35,7 +35,7 @@ export const validateReport = async ({
   waitTime?: string;
   contactFirstName?: string;
   contactLastName?: string;
-  concactRole?: string;
+  contactRole?: string;
   canDistribute?: boolean;
 }> => {
   const errors: ValidationError = {};
@@ -65,7 +65,7 @@ export const validateReport = async ({
     waitTime,
     contactFirstName,
     contactLastName,
-    concactRole,
+    contactRole,
     canDistribute,
   };
 };


### PR DESCRIPTION
`contactRole` was spelled `concactRole`