### PR TITLE
Fix for Useless conditional

### DIFF
--- a/src/controller/ReportsController.ts
+++ b/src/controller/ReportsController.ts
@@ -37,8 +37,7 @@ export class ReportsController {
       ? { location: { id: request.query.location } }
       : {};
 
-    const where =
-      truck || location || order ? { ...truck, ...order, ...location } : {};
+    const where = { ...truck, ...order, ...location };
 
     const [reports, count] = await Report.findAndCount({
       take,


### PR DESCRIPTION
The best fix is to remove the always-true conditional and directly construct `where` from the spread of the three optional filter objects.

In `src/controller/ReportsController.ts`, replace the `where` assignment around lines 40–41:

- From:
  - `const where = truck || location || order ? { ...truck, ...order, ...location } : {};`
- To:
  - `const where = { ...truck, ...order, ...location };`

This preserves current functionality exactly (same resulting object in all cases), removes dead conditional logic, and resolves the CodeQL finding. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._