### PR TITLE
Fix for Useless conditional

### DIFF
--- a/src/controller/ReportsController.ts
+++ b/src/controller/ReportsController.ts
@@ -37,8 +37,7 @@ export class ReportsController {
       ? { location: { id: request.query.location } }
       : {};
 
-    const where =
-      truck || location || order ? { ...truck, ...order, ...location } : {};
+    const where = { ...truck, ...order, ...location };
 
     const [reports, count] = await Report.findAndCount({
       take,


### PR DESCRIPTION
The fix is to remove the always-true conditional and directly construct the `where` object from the three partial filter objects.

Best fix without changing functionality:
- In `src/controller/ReportsController.ts`, replace line 40–41:
  - from conditional assignment using `truck || location || order ? ... : {}`
  - to direct merge: `{ ...truck, ...order, ...location }`
  
This preserves current behavior exactly (same result object), removes dead code, and resolves the CodeQL warning. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._